### PR TITLE
Add trailing "ends here" line for package.el compatibility

### DIFF
--- a/dired-toggle-sudo.el
+++ b/dired-toggle-sudo.el
@@ -95,3 +95,5 @@ If called with `universal-argument' (C-u), ask for username.
 	(dired fname)))))
 
 (provide 'dired-toggle-sudo)
+
+;;; dired-toggle-sudo.el ends here


### PR DESCRIPTION
This helps keep the package-buffer-info function happy.
